### PR TITLE
Fix IL3050 warnings when compiling a project depending on AsmArm64 as AOT

### DIFF
--- a/src/AsmArm64/Arm64EnumKind.cs
+++ b/src/AsmArm64/Arm64EnumKind.cs
@@ -9,7 +9,7 @@ namespace AsmArm64;
 /// <summary>
 /// Can be encoded in 3 bits
 /// </summary>
-[JsonConverter(typeof(JsonStringEnumConverter))]
+[JsonConverter(typeof(JsonStringEnumConverter<Arm64EnumKind>))]
 public enum Arm64EnumKind : byte
 {
     /// <summary>

--- a/src/AsmArm64/Arm64ExtendEncodingKind.cs
+++ b/src/AsmArm64/Arm64ExtendEncodingKind.cs
@@ -9,7 +9,7 @@ namespace AsmArm64;
 /// <summary>
 /// Internal enum used to specify the kind of encoding for an Arm64Extend instruction.
 /// </summary>
-[JsonConverter(typeof(JsonStringEnumConverter))]
+[JsonConverter(typeof(JsonStringEnumConverter<Arm64ExtendEncodingKind>))]
 enum Arm64ExtendEncodingKind : byte
 {
     /// <summary>

--- a/src/AsmArm64/Arm64ImmediateEncodingKind.cs
+++ b/src/AsmArm64/Arm64ImmediateEncodingKind.cs
@@ -9,7 +9,7 @@ namespace AsmArm64;
 /// <summary>
 /// The encoding kind for an immediate value.
 /// </summary>
-[JsonConverter(typeof(JsonStringEnumConverter))]
+[JsonConverter(typeof(JsonStringEnumConverter<Arm64ImmediateEncodingKind>))]
 enum Arm64ImmediateEncodingKind : byte
 {
     None,

--- a/src/AsmArm64/Arm64ImmediateValueEncodingKind.cs
+++ b/src/AsmArm64/Arm64ImmediateValueEncodingKind.cs
@@ -9,7 +9,7 @@ namespace AsmArm64;
 /// <summary>
 /// Internal enum for encoding an immediate value.
 /// </summary>
-[JsonConverter(typeof(JsonStringEnumConverter))]
+[JsonConverter(typeof(JsonStringEnumConverter<Arm64ImmediateValueEncodingKind>))]
 enum Arm64ImmediateValueEncodingKind : byte
 {
     None,

--- a/src/AsmArm64/Arm64LabelEncodingKind.cs
+++ b/src/AsmArm64/Arm64LabelEncodingKind.cs
@@ -9,7 +9,7 @@ namespace AsmArm64;
 /// <summary>
 /// Internal enum used to encode a label.
 /// </summary>
-[JsonConverter(typeof(JsonStringEnumConverter))]
+[JsonConverter(typeof(JsonStringEnumConverter<Arm64LabelEncodingKind>))]
 enum Arm64LabelEncodingKind : byte
 {
     None,

--- a/src/AsmArm64/Arm64MemoryEncodingKind.cs
+++ b/src/AsmArm64/Arm64MemoryEncodingKind.cs
@@ -9,7 +9,7 @@ namespace AsmArm64;
 /// <summary>
 /// Internal enum used to encode the kind of memory addressing for ARM64.
 /// </summary>
-[JsonConverter(typeof(JsonStringEnumConverter))]
+[JsonConverter(typeof(JsonStringEnumConverter<Arm64MemoryEncodingKind>))]
 enum Arm64MemoryEncodingKind : byte
 {
     None,

--- a/src/AsmArm64/Arm64MemoryExtendEncodingKind.cs
+++ b/src/AsmArm64/Arm64MemoryExtendEncodingKind.cs
@@ -9,7 +9,7 @@ namespace AsmArm64;
 /// <summary>
 /// Internal enum used to encode the kind of memory extend for ARM64.
 /// </summary>
-[JsonConverter(typeof(JsonStringEnumConverter))]
+[JsonConverter(typeof(JsonStringEnumConverter<Arm64MemoryExtendEncodingKind>))]
 enum Arm64MemoryExtendEncodingKind : byte
 {
     /// <summary>

--- a/src/AsmArm64/Arm64OperandKind.cs
+++ b/src/AsmArm64/Arm64OperandKind.cs
@@ -9,7 +9,7 @@ namespace AsmArm64;
 /// <summary>
 /// The kind of ARM64 operand.
 /// </summary>
-[JsonConverter(typeof(JsonStringEnumConverter))]
+[JsonConverter(typeof(JsonStringEnumConverter<Arm64OperandKind>))]
 public enum Arm64OperandKind : byte
 {
     /// <summary>

--- a/src/AsmArm64/Arm64RegisterEncodingKind.cs
+++ b/src/AsmArm64/Arm64RegisterEncodingKind.cs
@@ -9,7 +9,7 @@ namespace AsmArm64;
 /// <summary>
 /// Internal enum used to encode the kind of register for ARM64.
 /// </summary>
-[JsonConverter(typeof(JsonStringEnumConverter))]
+[JsonConverter(typeof(JsonStringEnumConverter<Arm64RegisterEncodingKind>))]
 internal enum Arm64RegisterEncodingKind : byte
 {
     None,

--- a/src/AsmArm64/Arm64RegisterIndexEncodingKind.cs
+++ b/src/AsmArm64/Arm64RegisterIndexEncodingKind.cs
@@ -9,7 +9,7 @@ namespace AsmArm64;
 /// <summary>
 /// Internal enum used to encode the kind of register index for ARM64.
 /// </summary>
-[JsonConverter(typeof(JsonStringEnumConverter))]
+[JsonConverter(typeof(JsonStringEnumConverter<Arm64RegisterIndexEncodingKind>))]
 internal enum Arm64RegisterIndexEncodingKind : byte
 {
     /// <summary>

--- a/src/AsmArm64/Arm64RegisterVectorArrangementEncodingKind.cs
+++ b/src/AsmArm64/Arm64RegisterVectorArrangementEncodingKind.cs
@@ -9,7 +9,7 @@ namespace AsmArm64;
 /// <summary>
 /// Internal enum used to encode the kind of vector arrangement for ARM64.
 /// </summary>
-[JsonConverter(typeof(JsonStringEnumConverter))]
+[JsonConverter(typeof(JsonStringEnumConverter<Arm64RegisterVectorArrangementEncodingKind>))]
 internal enum Arm64RegisterVectorArrangementEncodingKind : byte
 {
     None,

--- a/src/AsmArm64/Arm64ShiftEncodingKind.cs
+++ b/src/AsmArm64/Arm64ShiftEncodingKind.cs
@@ -9,7 +9,7 @@ namespace AsmArm64;
 /// <summary>
 /// Internal enum used to encode the kind of shift for ARM64.
 /// </summary>
-[JsonConverter(typeof(JsonStringEnumConverter))]
+[JsonConverter(typeof(JsonStringEnumConverter<Arm64ShiftEncodingKind>))]
 enum Arm64ShiftEncodingKind : byte
 {
     None,


### PR DESCRIPTION
I'm not sure why this doesn't get caught by the library trim analyzer, but I was getting

```
    ILC : AOT analysis warning IL3050: AsmArm64.Arm64MemoryExtendEncodingKind: Using member 'System.Text.Json.Serialization.JsonStringEnumConverter.JsonStringEnumConverter()' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. JsonStringEnumConverter cannot be statically analyzed and requires runtime code generation. Applications should use the generic JsonStringEnumConverter<TEnum> instead.
```

during build of an AOT project depending on AsmArm64. I fixed all other occurrences as well, so this should no longer happen no matter which parts of the project are being used.