### PR TITLE
 Add netstandard20 tfm support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ AsmArm64 is a powerful ARM64 Assembler and Disassembler .NET library.
 - **Easily disassemble** instructions and operands, including the knowledge of which operands and status flags are being read/write.
 - **High performance** / **zero allocation** library for disassembling / assembling instructions.
 - `15,000+` unit tests battle testing this library
-- Compatible with `net8.0+` and NativeAOT.
+- Compatible with `net8.0+` and NativeAOT. (`netstandard2.0` is also supported, but support is limited)
 
 ## 💻 Example
 

--- a/src/AsmArm64.Tests/AsmArm64.Tests.csproj
+++ b/src/AsmArm64.Tests/AsmArm64.Tests.csproj
@@ -7,9 +7,8 @@
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <EnableMSTestRunner>true</EnableMSTestRunner>
-    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net481'">
+    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AsmArm64.Tests/AsmArm64.Tests.csproj
+++ b/src/AsmArm64.Tests/AsmArm64.Tests.csproj
@@ -1,10 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net481</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+    <TestTargetFrameworks>$(TestTargetFrameworks);net481</TestTargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net481'">

--- a/src/AsmArm64.Tests/AsmArm64.Tests.csproj
+++ b/src/AsmArm64.Tests/AsmArm64.Tests.csproj
@@ -1,10 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net10.0;net481</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <EnableMSTestRunner>true</EnableMSTestRunner>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,6 +17,13 @@
     <PackageReference Include="Verify.DiffPlex" />
     <PackageReference Include="Verify.MSTest" />
     <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <PackageReference Include="PolySharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AsmArm64.Tests/TestAssembler.cs
+++ b/src/AsmArm64.Tests/TestAssembler.cs
@@ -838,7 +838,11 @@ public class TestAssembler : VerifyBase
         asm.RET();
         asm.Assemble();
 
+#if NETFRAMEWORK
+        return MemoryMarshal.Cast<uint, byte>(bufferList.Instructions.ToArray()).ToArray();
+#else
         return MemoryMarshal.Cast<uint, byte>(CollectionsMarshal.AsSpan(bufferList.Instructions)).ToArray();
+#endif
     }
 
     private static int CurrentLine([CallerLineNumber] int lineNumber = 0) => lineNumber;

--- a/src/AsmArm64/Arm64BitMaskImmediate64.cs
+++ b/src/AsmArm64/Arm64BitMaskImmediate64.cs
@@ -9,7 +9,10 @@ namespace AsmArm64;
 /// <summary>
 /// Represents an 8-bit immediate bitmask that can be used to encode a 64-bit mask.
 /// </summary>
-public readonly record struct Arm64BitMaskImmediate64 : ISpanFormattable
+public readonly record struct Arm64BitMaskImmediate64
+#if !NETSTANDARD2_0
+    : ISpanFormattable
+#endif
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="Arm64BitMaskImmediate64"/> struct.
@@ -136,5 +139,7 @@ public readonly record struct Arm64BitMaskImmediate64 : ISpanFormattable
     /// <param name="provider">The format provider to use.</param>
     /// <returns><c>true</c> if the formatting was successful; otherwise, <c>false</c>.</returns>
     public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
-        => format.Length == 0 || format[0] == 'X' ? destination.TryWrite(provider, $"0x{Value():16X}", out charsWritten) : Value().TryFormat(destination, out charsWritten, format, provider);
+        => format.Length == 0 || format[0] == 'X'
+            ? destination.TryWrite(provider, $"0x{Value():16X}", out charsWritten)
+            : Value().TryFormat(destination, out charsWritten, format, provider);
 }

--- a/src/AsmArm64/Arm64Disassembler.cs
+++ b/src/AsmArm64/Arm64Disassembler.cs
@@ -216,7 +216,11 @@ public class Arm64Disassembler
 
                     if (Options.PrintAssemblyBytes)
                     {
+#if NETSTANDARD2_0
+                        Span<byte> bytes = BitConverter.GetBytes(rawInstruction);
+#else
                         var bytes = MemoryMarshal.AsBytes(new Span<uint>(ref rawInstruction));
+#endif
                         var assemblyBytes = $"{FormatHexByte(bytes[0])} {FormatHexByte(bytes[1])} {FormatHexByte(bytes[2])} {FormatHexByte(bytes[3])}";
                         assemblyBytes.AsSpan().TryCopyTo(runningSpan);
                         var localCharsWritten = assemblyBytes.Length;
@@ -275,10 +279,13 @@ public class Arm64Disassembler
                     }
 
                     runningSpan = textSpan.Slice(0, charsWritten);
+
+#if NETSTANDARD2_0
+                    writer.WriteLine(runningSpan.TrimEnd(' ').ToString());
+#else
                     runningSpan = runningSpan.TrimEnd(' ');
-
                     writer.WriteLine(runningSpan);
-
+#endif
                     if (instruction.Id.IsBranch())
                     {
                         nextNewLine = true;
@@ -337,7 +344,11 @@ public class Arm64Disassembler
     }
 
     private void WriteIndentSize(Span<char> textSpan, TextWriter writer)
+#if NETSTANDARD2_0
+        => writer.Write(GetIndentSpan(textSpan).ToArray());
+#else
         => writer.Write(GetIndentSpan(textSpan));
+#endif
 
     private string FormatAddress(long address)
         => Options.AddressPrefix + address.ToString(Options.UseUppercaseHex ? "X16" : "x16", CultureInfo.InvariantCulture);
@@ -418,7 +429,11 @@ public class Arm64Disassembler
             runningSpan = runningSpan.Slice(byteCharsWritten);
         }
 
+#if NETSTANDARD2_0
+        writer.WriteLine(textSpan.Slice(0, charsWritten).ToArray());
+#else
         writer.WriteLine(textSpan.Slice(0, charsWritten));
+#endif
     }
 
     private void PrintLabel(int offset, Span<char> textSpan, TextWriter writer, bool nextNewLine, bool isFirstLabel, bool isLast)
@@ -439,7 +454,12 @@ public class Arm64Disassembler
                 var result = textSpan.TryWrite($"{FormatLocalLabel(labelIndex)}:", out charsWritten);
                 Debug.Assert(result);
             }
+
+#if NETSTANDARD2_0
+            writer.WriteLine(textSpan.Slice(0, charsWritten).ToArray());
+#else
             writer.WriteLine(textSpan.Slice(0, charsWritten));
+#endif
         }
         else
         {

--- a/src/AsmArm64/Arm64FloatImmediate.cs
+++ b/src/AsmArm64/Arm64FloatImmediate.cs
@@ -9,7 +9,10 @@ namespace AsmArm64;
 /// <summary>
 /// Represents an 8-bit floating-point immediate value.
 /// </summary>
-public readonly record struct Arm64FloatImmediate : ISpanFormattable
+public readonly record struct Arm64FloatImmediate
+#if !NETSTANDARD2_0
+    : ISpanFormattable
+#endif
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="Arm64FloatImmediate"/> struct with the specified encoded value.

--- a/src/AsmArm64/Arm64ImmediateOperand.cs
+++ b/src/AsmArm64/Arm64ImmediateOperand.cs
@@ -170,7 +170,11 @@ public readonly struct Arm64ImmediateOperand : IArm64Operand
         Span<char> span = stackalloc char[16];
         var result = TryFormat(span, out var charsWritten, format, formatProvider);
         Debug.Assert(result);
+#if NETSTANDARD2_0
+        return new string(span.Slice(0, charsWritten).ToArray());
+#else
         return new string(span.Slice(0, charsWritten));
+#endif
     }
 
     /// <inheritdoc />

--- a/src/AsmArm64/Arm64Instruction.cs
+++ b/src/AsmArm64/Arm64Instruction.cs
@@ -13,7 +13,10 @@ using EntryIndex = int;
 /// <summary>
 /// Encoded instruction table for ARM64.
 /// </summary>
-public readonly unsafe struct Arm64Instruction : ISpanFormattable
+public readonly unsafe struct Arm64Instruction
+#if !NETSTANDARD2_0
+    : ISpanFormattable
+#endif
 {
     internal readonly ulong Descriptor;
     internal readonly byte* OperandsPtr;

--- a/src/AsmArm64/Arm64InstructionBufferByStream.cs
+++ b/src/AsmArm64/Arm64InstructionBufferByStream.cs
@@ -34,17 +34,32 @@ public class Arm64InstructionBufferByStream : Arm64InstructionBuffer
     {
         Stream.Seek(offset, SeekOrigin.Begin);
         Unsafe.SkipInit(out Arm64RawInstruction rawInstruction);
+#if NETSTANDARD2_0
+        Span<byte> buffer = stackalloc byte[4];
+        if (Stream.ReadAtLeast(buffer, 4, throwOnEndOfStream: false) != 4)
+        {
+            throw new InvalidOperationException("Cannot read instruction");
+        }
+        return MemoryMarshal.Read<uint>(buffer);
+#else
         if (Stream.Read(MemoryMarshal.CreateSpan(ref Unsafe.As<uint, byte>(ref rawInstruction), 4)) != 4)
         {
             throw new InvalidOperationException("Cannot read instruction");
         }
         return rawInstruction;
+#endif
     }
 
     /// <inheritdoc />
     public override void WriteAt(uint offset, Arm64RawInstruction rawInstruction)
     {
         Stream.Seek(offset, SeekOrigin.Begin);
+
+#if NETSTANDARD2_0
+        byte[] bytes = BitConverter.GetBytes(rawInstruction);
+        Stream.Write(bytes, 0, bytes.Length);
+#else
         Stream.Write(MemoryMarshal.CreateSpan(ref Unsafe.As<uint, byte>(ref rawInstruction), 4));
+#endif
     }
 }

--- a/src/AsmArm64/Arm64InvertedShiftedImmediate32.cs
+++ b/src/AsmArm64/Arm64InvertedShiftedImmediate32.cs
@@ -7,7 +7,10 @@ namespace AsmArm64;
 /// <summary>
 /// Represents a 32-bit inverted shifted immediate value.
 /// </summary>
-public readonly record struct Arm64InvertedShiftedImmediate32 : ISpanFormattable
+public readonly record struct Arm64InvertedShiftedImmediate32
+#if !NETSTANDARD2_0
+    : ISpanFormattable
+#endif
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="Arm64InvertedShiftedImmediate32"/> struct.

--- a/src/AsmArm64/Arm64InvertedShiftedImmediate64.cs
+++ b/src/AsmArm64/Arm64InvertedShiftedImmediate64.cs
@@ -7,7 +7,10 @@ namespace AsmArm64;
 /// <summary>
 /// Represents a 64-bit inverted shifted immediate value.
 /// </summary>
-public readonly record struct Arm64InvertedShiftedImmediate64 : ISpanFormattable
+public readonly record struct Arm64InvertedShiftedImmediate64
+#if !NETSTANDARD2_0
+    : ISpanFormattable
+#endif
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="Arm64InvertedShiftedImmediate64"/> struct.

--- a/src/AsmArm64/Arm64LabelOffset.cs
+++ b/src/AsmArm64/Arm64LabelOffset.cs
@@ -8,7 +8,10 @@ namespace AsmArm64;
 /// Represents a label, a relative offset from the current instruction.
 /// </summary>
 /// <param name="Value">A relative offset to the current instruction</param>
-public readonly record struct Arm64LabelOffset(int Value) : ISpanFormattable
+public readonly record struct Arm64LabelOffset(int Value)
+#if !NETSTANDARD2_0
+    : ISpanFormattable
+#endif
 {
     /// <inheritdoc />
     public string ToString(string? format, IFormatProvider? formatProvider)

--- a/src/AsmArm64/Arm64LogicalImmediate32.cs
+++ b/src/AsmArm64/Arm64LogicalImmediate32.cs
@@ -9,7 +9,10 @@ namespace AsmArm64;
 /// <summary>
 /// Represents a 32-bit logical immediate value for AArch64.
 /// </summary>
-public readonly record struct Arm64LogicalImmediate32 : ISpanFormattable
+public readonly record struct Arm64LogicalImmediate32
+#if !NETSTANDARD2_0
+    : ISpanFormattable
+#endif
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="Arm64LogicalImmediate32"/> struct.

--- a/src/AsmArm64/Arm64LogicalImmediate64.cs
+++ b/src/AsmArm64/Arm64LogicalImmediate64.cs
@@ -9,7 +9,10 @@ namespace AsmArm64;
 /// <summary>
 /// Represents a 64-bit logical immediate value for AArch64.
 /// </summary>
-public readonly record struct Arm64LogicalImmediate64 : ISpanFormattable
+public readonly record struct Arm64LogicalImmediate64
+#if !NETSTANDARD2_0
+    : ISpanFormattable
+#endif
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="Arm64LogicalImmediate64"/> struct.

--- a/src/AsmArm64/Arm64Memory.cs
+++ b/src/AsmArm64/Arm64Memory.cs
@@ -130,7 +130,11 @@ public readonly record struct Arm64MemoryAccessorAny : IArm64MemoryAccessor
         Span<char> span = stackalloc char[32];
         var result = TryFormat(span, out var charsWritten, format, formatProvider);
         Debug.Assert(result);
+#if NETSTANDARD2_0
+        return new string(span.Slice(0, charsWritten).ToArray());
+#else
         return new string(span.Slice(0, charsWritten));
+#endif
     }
 
     /// <inheritdoc />

--- a/src/AsmArm64/Arm64MemoryOperand.cs
+++ b/src/AsmArm64/Arm64MemoryOperand.cs
@@ -219,7 +219,11 @@ public readonly struct Arm64MemoryOperand : IArm64Operand
         Span<char> span = stackalloc char[32];
         var result = TryFormat(span, out var charsWritten, format, formatProvider);
         Debug.Assert(result);
+#if NETSTANDARD2_0
+        return new string(span.Slice(0, charsWritten).ToArray());
+#else
         return new string(span.Slice(0, charsWritten));
+#endif
     }
 
     /// <inheritdoc />

--- a/src/AsmArm64/Arm64ShiftedImmediate32.cs
+++ b/src/AsmArm64/Arm64ShiftedImmediate32.cs
@@ -7,7 +7,10 @@ namespace AsmArm64;
 /// <summary>
 /// Represents a 32-bit shifted immediate value.
 /// </summary>
-public readonly record struct Arm64ShiftedImmediate32 : ISpanFormattable
+public readonly record struct Arm64ShiftedImmediate32
+#if !NETSTANDARD2_0
+    : ISpanFormattable
+#endif
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="Arm64ShiftedImmediate32"/> struct.

--- a/src/AsmArm64/Arm64ShiftedImmediate64.cs
+++ b/src/AsmArm64/Arm64ShiftedImmediate64.cs
@@ -7,7 +7,10 @@ namespace AsmArm64;
 /// <summary>
 /// Represents a 64-bit shifted immediate value.
 /// </summary>
-public readonly record struct Arm64ShiftedImmediate64 : ISpanFormattable
+public readonly record struct Arm64ShiftedImmediate64
+#if !NETSTANDARD2_0
+    : ISpanFormattable
+#endif
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="Arm64ShiftedImmediate64"/> struct.

--- a/src/AsmArm64/Arm64SystemRegister.cs
+++ b/src/AsmArm64/Arm64SystemRegister.cs
@@ -10,7 +10,10 @@ namespace AsmArm64;
 /// <summary>
 /// Defines a system register for ARM64.
 /// </summary>
-public readonly struct Arm64SystemRegister : IEquatable<Arm64SystemRegister>, ISpanFormattable
+public readonly struct Arm64SystemRegister : IEquatable<Arm64SystemRegister>
+#if !NETSTANDARD2_0
+    , ISpanFormattable
+#endif
 {
     // 16-bit value for the Arm64SystemRegisterId enum index
     // 16-bit value for the system register

--- a/src/AsmArm64/AsmArm64.csproj
+++ b/src/AsmArm64/AsmArm64.csproj
@@ -1,10 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
+  </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
     <!-- Enable AOT analyzers -->
     <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
@@ -128,4 +130,17 @@
       <DependentUpon>Arm64SystemRegisterKind.tt</DependentUpon>
     </Compile>
   </ItemGroup>
+
+  <!-- Settings for netstandard2.0 -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="PolySharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="System.Buffers" />
+    <PackageReference Include="System.Memory" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
+    <PackageReference Include="System.Text.Json" />
+  </ItemGroup>
+
 </Project>

--- a/src/AsmArm64/IArm64MemoryAccessor.cs
+++ b/src/AsmArm64/IArm64MemoryAccessor.cs
@@ -7,7 +7,10 @@ namespace AsmArm64;
 /// <summary>
 /// Interface for accessing ARM64 memory.
 /// </summary>
-public interface IArm64MemoryAccessor : ISpanFormattable
+public interface IArm64MemoryAccessor
+#if !NETSTANDARD2_0
+    : ISpanFormattable
+#endif
 {
     /// <summary>
     /// Gets the base register kind.

--- a/src/AsmArm64/IArm64MemoryExtend.cs
+++ b/src/AsmArm64/IArm64MemoryExtend.cs
@@ -7,7 +7,10 @@ namespace AsmArm64;
 /// <summary>
 /// Represents an interface for ARM64 memory with an extend operation.
 /// </summary>
-public interface IArm64MemoryExtend : ISpanFormattable
+public interface IArm64MemoryExtend
+#if !NETSTANDARD2_0
+    : ISpanFormattable
+#endif
 {
     /// <summary>
     /// Gets the kind of the extend operation.

--- a/src/AsmArm64/IArm64Operand.cs
+++ b/src/AsmArm64/IArm64Operand.cs
@@ -7,7 +7,10 @@ namespace AsmArm64;
 /// <summary>
 /// Represents an interface for an ARM64 operand.
 /// </summary>
-public interface IArm64Operand : ISpanFormattable
+public interface IArm64Operand
+#if !NETSTANDARD2_0
+    : ISpanFormattable
+#endif
 {
     /// <summary>
     /// Gets the kind of the operand.

--- a/src/AsmArm64/IArm64Register.cs
+++ b/src/AsmArm64/IArm64Register.cs
@@ -7,7 +7,10 @@ namespace AsmArm64;
 /// <summary>
 /// Defines the interface for a register.
 /// </summary>
-public interface IArm64Register : ISpanFormattable
+public interface IArm64Register
+#if !NETSTANDARD2_0
+    : ISpanFormattable
+#endif
 {
     /// <summary>
     /// Gets the kind of register.

--- a/src/AsmArm64/IArm64RegisterGroup.cs
+++ b/src/AsmArm64/IArm64RegisterGroup.cs
@@ -7,7 +7,10 @@ namespace AsmArm64;
 /// <summary>
 /// Defines the interface for a register group.
 /// </summary>
-public interface IArm64RegisterGroup : ISpanFormattable
+public interface IArm64RegisterGroup
+#if !NETSTANDARD2_0
+    : ISpanFormattable
+#endif
 {
     /// <summary>
     /// Gets the base register of this group

--- a/src/AsmArm64/Polyfills/netstandard2.0/BitConverterExtensions.cs
+++ b/src/AsmArm64/Polyfills/netstandard2.0/BitConverterExtensions.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// Licensed under the BSD-Clause 2 license.
+// See license.txt file in the project root for full license information.
+
+#if NETSTANDARD2_0
+using System.Runtime.CompilerServices;
+
+namespace System;
+
+internal static class BitConverterExtensions
+{
+    extension(BitConverter)
+    {
+        public static float Int32BitsToSingle(int value) => Unsafe.BitCast<int, float>(value);
+
+        public static int SingleToInt32Bits(float value) => Unsafe.BitCast<float, int>(value);
+
+        public static uint ToUInt32(ReadOnlySpan<byte> value)
+        {
+            return ToUInt32(value.ToArray());
+        }
+
+        public static int ToInt32(ReadOnlySpan<byte> value)
+        {
+            return ToInt32(value.ToArray());
+        }
+
+        public static uint ToUInt32(byte[] value)
+        {
+            return BitConverter.ToUInt32(value, 0);
+        }
+
+        public static int ToInt32(byte[] value)
+        {
+            return BitConverter.ToInt32(value, 0);
+        }
+    }
+}
+#endif

--- a/src/AsmArm64/Polyfills/netstandard2.0/BitOperations.cs
+++ b/src/AsmArm64/Polyfills/netstandard2.0/BitOperations.cs
@@ -1,0 +1,115 @@
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// Licensed under the BSD-Clause 2 license.
+// See license.txt file in the project root for full license information.
+
+#if NETSTANDARD2_0
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace System.Numerics;
+
+internal static class BitOperations
+{
+    private static ReadOnlySpan<byte> TrailingZeroCountDeBruijn => // 32
+       [
+           00, 01, 28, 02, 29, 14, 24, 03,
+            30, 22, 20, 15, 25, 17, 04, 08,
+            31, 27, 13, 23, 21, 19, 16, 07,
+            26, 12, 18, 06, 11, 05, 10, 09
+       ];
+
+    private static ReadOnlySpan<byte> Log2DeBruijn => new byte[32]
+       {
+            00, 09, 01, 10, 13, 21, 02, 29,
+            11, 14, 16, 18, 22, 25, 03, 30,
+            08, 12, 20, 28, 15, 17, 24, 07,
+            19, 27, 23, 06, 26, 05, 04, 31
+       };
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int TrailingZeroCount(int value)
+        => TrailingZeroCount((uint)value);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int TrailingZeroCount(uint value)
+    {
+        // Unguarded fallback contract is 0->0, BSF contract is 0->undefined
+        if (value == 0)
+        {
+            return 32;
+        }
+
+        // uint.MaxValue >> 27 is always in range [0 - 31] so we use Unsafe.AddByteOffset to avoid bounds check
+        return Unsafe.AddByteOffset(
+            // Using deBruijn sequence, k=2, n=5 (2^5=32) : 0b_0000_0111_0111_1100_1011_0101_0011_0001u
+            ref MemoryMarshal.GetReference(TrailingZeroCountDeBruijn),
+            // uint|long -> IntPtr cast on 32-bit platforms does expensive overflow checks not needed here
+            (IntPtr)(int)(((value & (uint)-(int)value) * 0x077CB531u) >> 27)); // Multi-cast mitigates redundant conv.u8
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int TrailingZeroCount(ulong value)
+    {
+        uint lo = (uint)value;
+
+        if (lo == 0)
+        {
+            return 32 + TrailingZeroCount((uint)(value >> 32));
+        }
+
+        return TrailingZeroCount(lo);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int LeadingZeroCount(uint value)
+    {
+        // Unguarded fallback contract is 0->31, BSR contract is 0->undefined
+        if (value == 0)
+        {
+            return 32;
+        }
+
+        return 31 ^ Log2SoftwareFallback(value);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int LeadingZeroCount(ulong value)
+    {
+        uint hi = (uint)(value >> 32);
+
+        if (hi == 0)
+        {
+            return 32 + LeadingZeroCount((uint)value);
+        }
+
+        return LeadingZeroCount(hi);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ulong RotateRight(ulong value, int offset)
+        => (value >> offset) | (value << (64 - offset));
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsPow2(int value) => (value & (value - 1)) == 0 && value > 0;
+
+    private static int Log2SoftwareFallback(uint value)
+    {
+        // No AggressiveInlining due to large method size
+        // Has conventional contract 0->0 (Log(0) is undefined)
+
+        // Fill trailing zeros with ones, eg 00010010 becomes 00011111
+        value |= value >> 01;
+        value |= value >> 02;
+        value |= value >> 04;
+        value |= value >> 08;
+        value |= value >> 16;
+
+        // uint.MaxValue >> 27 is always in range [0 - 31] so we use Unsafe.AddByteOffset to avoid bounds check
+        return Unsafe.AddByteOffset(
+            // Using deBruijn sequence, k=2, n=5 (2^5=32) : 0b_0000_0111_1100_0100_1010_1100_1101_1101u
+            ref MemoryMarshal.GetReference(Log2DeBruijn),
+            // uint|long -> IntPtr cast on 32-bit platforms does expensive overflow checks not needed here
+            (IntPtr)(int)((value * 0x07C4ACDDu) >> 27));
+    }
+}
+#endif

--- a/src/AsmArm64/Polyfills/netstandard2.0/CollectionsMarshal.cs
+++ b/src/AsmArm64/Polyfills/netstandard2.0/CollectionsMarshal.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// Licensed under the BSD-Clause 2 license.
+// See license.txt file in the project root for full license information.
+
+#if NETSTANDARD2_0
+namespace System.Runtime.InteropServices;
+
+internal static class CollectionsMarshal
+{
+    extension<T>(List<T> list)
+    {
+        public void SetCount(int count)
+        {
+            if (count < list.Count)
+            {
+                list.RemoveRange(count, list.Count - count);
+                return;
+            }
+
+            if (count > list.Count)
+            {
+                list.Capacity = Math.Max(list.Capacity, count);
+
+                while (list.Count < count)
+                {
+                    list.Add(default!);
+                }
+            }
+        }
+    }
+}
+#endif

--- a/src/AsmArm64/Polyfills/netstandard2.0/DictionaryExtensions.cs
+++ b/src/AsmArm64/Polyfills/netstandard2.0/DictionaryExtensions.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// Licensed under the BSD-Clause 2 license.
+// See license.txt file in the project root for full license information.
+
+#if NETSTANDARD2_0
+namespace System.Collections.Generic;
+
+internal static class DictionaryExtensions
+{
+    extension<TKey, TValue>(Dictionary<TKey, TValue> dictionary)
+    {
+        public bool TryAdd(TKey key, TValue value)
+        {
+            if (dictionary.ContainsKey(key))
+                return false;
+
+            dictionary.Add(key, value);
+            return true;
+        }
+    }
+}
+#endif

--- a/src/AsmArm64/Polyfills/netstandard2.0/EnumExtensions.cs
+++ b/src/AsmArm64/Polyfills/netstandard2.0/EnumExtensions.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// Licensed under the BSD-Clause 2 license.
+// See license.txt file in the project root for full license information.
+
+#if NETSTANDARD2_0
+using System.Diagnostics.CodeAnalysis;
+
+namespace System;
+
+internal static class EnumExtensions
+{
+    extension(Enum)
+    {
+        public static bool TryFormat<TEnum>(TEnum value, Span<char> destination, out int charsWritten, [StringSyntax(StringSyntaxAttribute.EnumFormat)] ReadOnlySpan<char> format = default)
+            where TEnum : struct, Enum
+        {
+            value.TryFormat(destination, out charsWritten, format);
+            return charsWritten > 0;
+        }
+
+        public static bool IsDefined<TEnum>(TEnum value)
+            where TEnum : struct, Enum
+        {
+            return Enum.IsDefined(typeof(TEnum), value);
+        }
+    }
+
+    extension<T>(T value)
+        where T : struct, IFormattable
+    {
+        public bool TryFormat(
+            Span<char> destination,
+            out int charsWritten,
+            ReadOnlySpan<char> format = default,
+            IFormatProvider? provider = null)
+        {
+            string text =
+                value.ToString(
+                format.IsEmpty ? null : format.ToString(),
+                provider);
+
+            if (text.Length > destination.Length)
+            {
+                charsWritten = 0;
+                return false;
+            }
+
+            text.AsSpan().CopyTo(destination);
+            charsWritten = text.Length;
+            return true;
+        }
+    }
+}
+#endif

--- a/src/AsmArm64/Polyfills/netstandard2.0/ExceptionExtensions.cs
+++ b/src/AsmArm64/Polyfills/netstandard2.0/ExceptionExtensions.cs
@@ -1,0 +1,98 @@
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// Licensed under the BSD-Clause 2 license.
+// See license.txt file in the project root for full license information.
+
+#if NETSTANDARD2_0
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+namespace System;
+
+internal static class ExceptionExtensions
+{
+    extension(ArgumentNullException)
+    {
+        public static void ThrowIfNull(object? argument, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
+        {
+            if (argument is null)
+            {
+                throw new ArgumentNullException(paramName);
+            }
+        }
+    }
+
+    extension(ObjectDisposedException)
+    {
+        public static void ThrowIf([DoesNotReturnIf(true)] bool condition, object instance)
+        {
+            if (condition)
+            {
+                throw new ObjectDisposedException(instance?.GetType().FullName);
+            }
+        }
+    }
+
+    extension(ArgumentOutOfRangeException)
+    {
+        public static void ThrowIfGreaterThanOrEqual<T>(T value, T other, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+          where T : IComparable<T>
+        {
+            if (value.CompareTo(other) >= 0)
+                throw new ArgumentOutOfRangeException(paramName, value, $"{paramName} ('{value}') must not be greater than or equal to '{other}'.");
+        }
+
+        public static void ThrowIfGreaterThan<T>(T value, T other, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+          where T : IComparable<T>
+        {
+            if (value.CompareTo(other) > 0)
+                throw new ArgumentOutOfRangeException(paramName, value, $"{paramName} ('{value}') must not be greater than '{other}'.");
+        }
+
+        public static void ThrowIfNegative<T>(T value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+            where T : struct, global::System.IComparable<T>
+        {
+            switch (value)
+            {
+                case byte or ushort or uint or ulong or char:
+                    return;
+                case sbyte n:
+                    if (n < 0)
+                        ThrowArgumentOutOfRangeException(paramName, value);
+                    return;
+                case short n:
+                    if (n < 0)
+                        ThrowArgumentOutOfRangeException(paramName, value);
+                    return;
+                case int n:
+                    if (n < 0)
+                        ThrowArgumentOutOfRangeException(paramName, value);
+                    return;
+                case long n:
+                    if (n < 0L)
+                        ThrowArgumentOutOfRangeException(paramName, value);
+                    return;
+
+                case float n:
+                    if (n < 0F)
+                        ThrowArgumentOutOfRangeException(paramName, value);
+                    return;
+                case double n:
+                    if (n < 0D)
+                        ThrowArgumentOutOfRangeException(paramName, value);
+                    return;
+                case decimal n:
+                    if (n < 0M)
+                        ThrowArgumentOutOfRangeException(paramName, value);
+                    return;
+                default:
+                    throw new InvalidOperationException($"Invalid type '{typeof(T).AssemblyQualifiedName}' for {paramName}.");
+            }
+
+            static void ThrowArgumentOutOfRangeException(string? paramName, object value)
+            {
+                throw new ArgumentOutOfRangeException(paramName, value, $"{paramName} ('{value}') must not be negative.");
+            }
+        }
+    }
+}
+#endif

--- a/src/AsmArm64/Polyfills/netstandard2.0/SpanExtensions.cs
+++ b/src/AsmArm64/Polyfills/netstandard2.0/SpanExtensions.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// Licensed under the BSD-Clause 2 license.
+// See license.txt file in the project root for full license information.
+
+#if NETSTANDARD2_0
+namespace System;
+
+internal static class SpanExtensions
+{
+    public static bool TryWrite(
+        this Span<char> destination,
+        string value,
+        out int charsWritten)
+    {
+        return TryWrite(destination, null, value, out charsWritten);
+    }
+
+    public static bool TryWrite(
+        this Span<char> destination,
+        IFormatProvider? provider,
+        string value,
+        out int charsWritten)
+    {
+        if (provider != null)
+            throw new ArgumentException();
+
+        string text = value;
+        if (text.Length > destination.Length)
+        {
+            charsWritten = 0;
+            return false;
+        }
+
+        text.AsSpan().CopyTo(destination);
+        charsWritten = text.Length;
+        return true;
+    }
+}
+#endif

--- a/src/AsmArm64/Polyfills/netstandard2.0/StreamExtensions.cs
+++ b/src/AsmArm64/Polyfills/netstandard2.0/StreamExtensions.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// Licensed under the BSD-Clause 2 license.
+// See license.txt file in the project root for full license information.
+
+#if NETSTANDARD2_0
+namespace System.IO;
+
+internal static class StreamExtensions
+{
+    extension(Stream stream)
+    {
+        public int ReadAtLeast(
+            Span<byte> buffer,
+            int minimumBytes,
+            bool throwOnEndOfStream = true)
+        {
+            if ((uint)minimumBytes > (uint)buffer.Length)
+                throw new ArgumentOutOfRangeException(nameof(minimumBytes));
+
+            int totalRead = 0;
+            byte[] temp = new byte[Math.Min(4096, minimumBytes)];
+
+            while (totalRead < minimumBytes)
+            {
+                int read = stream.Read(temp, 0, Math.Min(temp.Length, minimumBytes - totalRead));
+
+                if (read == 0)
+                {
+                    if (throwOnEndOfStream)
+                        throw new EndOfStreamException();
+
+                    break;
+                }
+
+                temp.AsSpan(0, read).CopyTo(buffer.Slice(totalRead));
+                totalRead += read;
+            }
+
+            return totalRead;
+        }
+    }
+}
+#endif

--- a/src/AsmArm64/Polyfills/netstandard2.0/StringExtensions.cs
+++ b/src/AsmArm64/Polyfills/netstandard2.0/StringExtensions.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// Licensed under the BSD-Clause 2 license.
+// See license.txt file in the project root for full license information.
+
+#if NETSTANDARD2_0
+namespace System.Collections.Generic;
+
+internal static class StringExtensions
+{
+    extension(string value)
+    {
+        public bool TryCopyTo(Span<char> destination)
+        {
+            if (destination.Length < value.Length)
+                return false;
+
+            value.AsSpan().CopyTo(destination);
+            return true;
+        }
+    }
+}
+#endif

--- a/src/AsmArm64/Polyfills/netstandard2.0/UnsafeExtensions.cs
+++ b/src/AsmArm64/Polyfills/netstandard2.0/UnsafeExtensions.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Alexandre Mutel. All rights reserved.
+// Licensed under the BSD-Clause 2 license.
+// See license.txt file in the project root for full license information.
+
+#if NETSTANDARD2_0
+namespace System.Runtime.CompilerServices;
+
+internal static class UnsafeExtensions
+{
+    extension(Unsafe)
+    {
+        // Exceptions:
+        //   T:System.NotSupportedException:
+        //     The size of TFrom and TTo are not the same.
+        public static TTo BitCast<TFrom, TTo>(TFrom source)
+            where TFrom : struct
+            where TTo : struct
+        {
+            if (Unsafe.SizeOf<TFrom>() != Unsafe.SizeOf<TTo>())
+                throw new NotSupportedException("Source and destination types must have the same size.");
+
+            return Unsafe.As<TFrom, TTo>(ref source);
+        }
+    }
+}
+#endif

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,5 +2,6 @@
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,6 +2,6 @@
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>14</LangVersion>
   </PropertyGroup>
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -11,4 +11,11 @@
     <PackageVersion Include="Verify.DiffPlex" Version="3.1.2" />
     <PackageVersion Include="Verify.MSTest" Version="31.16.3" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageVersion Include="PolySharp" Version="1.16.0" />
+    <PackageVersion Include="System.Buffers" Version="4.6.1" />
+    <PackageVersion Include="System.Memory" Version="4.6.3" />
+    <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2"/>
+    <PackageVersion Include="System.Text.Json" Version="10.0.9" />
+  </ItemGroup>
 </Project>

--- a/src/global.json
+++ b/src/global.json
@@ -3,8 +3,5 @@
         "version": "10.0.100",
         "rollForward": "latestMinor",
         "allowPrerelease": false
-    },
-    "test": {
-      "runner": "Microsoft.Testing.Platform"
     }
 }

--- a/src/global.json
+++ b/src/global.json
@@ -3,5 +3,8 @@
         "version": "10.0.100",
         "rollForward": "latestMinor",
         "allowPrerelease": false
+    },
+    "test": {
+      "runner": "Microsoft.Testing.Platform"
     }
 }


### PR DESCRIPTION
This PR intended to resolve #10.

Add `netstandard2.0` tfm support with minimal code changes.

### Change summaries

#### 1. [chore: add netstandard2.0 tfm to project with settings](https://github.com/xoofx/AsmArm64/commit/e83f88c531b2a87fea384ffef7fc5f774ef4034a)
- Add `netstandard2.0` tfm to project
- Add required NuGet package references for `netstandard2.0`
- Add `<LangVersion>latest</LangVersion` setting on `Directory.Build.props`
- Add `netstandard2.0` support statement on `readme.md`

#### 2. [chore: add polyfills for netstandard2.0 tfm](https://github.com/xoofx/AsmArm64/commit/7fbdab31c131ae7f474658b8196f635d3fdab304)
Add additional polyfills/backported code for `netstandard2.0` build.

 #### 4. [chore: fix build errors for netstandard2.0 tfm](https://github.com/xoofx/AsmArm64/commit/8d6d99631b9f3d5841f01d997fb9c61cb7200a64)
Fix build errors with `#if NETSTANDARD2_0` and replace code to use polyfills.

 #### 4. [chore: add net481 tests and enable microsoft.testing.platform](https://github.com/xoofx/AsmArm64/commit/ee94ab816a2aabb1a61ef177b2d64edcd3399f1b)
- Add `net481` tfm on test project
- Fix build error that occurred on `net481`
- Migrate test runner from `VSTest` to `Microsoft.Testing.Platform`   
  (It's required because following build error occurred on net481 build with OutputType:Exe)
    > CS5001: Program does not contain a static 'Main' method suitable for an entry point
